### PR TITLE
Let's be consistent

### DIFF
--- a/resources/js/theme/prompt.js
+++ b/resources/js/theme/prompt.js
@@ -20,7 +20,7 @@ $(function () {
                     $('.bootbox.modal')
                         .find('.modal-dialog')
                         .removeClass('shake')
-                        .removeClass('animated')
+                        .removeClass('animated');
                 }, 1000);
 
                 return false;


### PR DESCRIPTION
I suppose it's a typo.

Why don't you use a linter?
![image](https://user-images.githubusercontent.com/5930429/27113123-bf80ec1c-50c3-11e7-8f74-662424de3c82.png)
